### PR TITLE
Ref #9 fixed SensorNotRequired warning

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -22,7 +22,7 @@
   <script src="lib/angular/angular.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.4.0/ui-bootstrap.min.js"></script>
   <script src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.4.0/ui-bootstrap-tpls.min.js"></script>
-  <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&sensor=false&key=AIzaSyCOUo69jud8ZVGG4sa7ijZ3y6XL_XNmkXg"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?v=3.exp&libraries=places&key=AIzaSyCOUo69jud8ZVGG4sa7ijZ3y6XL_XNmkXg"></script>
   <script src="js/app.js"></script>
   <script src="js/services.js"></script>
   <script src="js/controllers.js"></script>


### PR DESCRIPTION
While using the code, we were getting a google maps api related warning in the browsers' console. This commit resolves that warning.