### PR TITLE
Ref #11 now using console.log in web-server script

### DIFF
--- a/scripts/web-server.js
+++ b/scripts/web-server.js
@@ -41,7 +41,7 @@ function HttpServer(handlers) {
 HttpServer.prototype.start = function(port) {
   this.port = port;
   this.server.listen(port);
-  util.puts('Http Server running at http://localhost:' + port + '/');
+  console.log('Http Server running at http://localhost:' + port + '/');
 };
 
 HttpServer.prototype.parseUrl_ = function(urlString) {
@@ -55,7 +55,7 @@ HttpServer.prototype.handleRequest_ = function(req, res) {
   if (req.headers['user-agent']) {
     logEntry += ' ' + req.headers['user-agent'];
   }
-  util.puts(logEntry);
+  console.log(logEntry);
   req.url = this.parseUrl_(req.url);
   var handler = this.handlers[req.method];
   if (!handler) {
@@ -116,8 +116,8 @@ StaticServlet.prototype.sendError_ = function(req, res, error) {
   res.write('<title>Internal Server Error</title>\n');
   res.write('<h1>Internal Server Error</h1>');
   res.write('<pre>' + escapeHtml(util.inspect(error)) + '</pre>');
-  util.puts('500 Internal Server Error');
-  util.puts(util.inspect(error));
+  console.log('500 Internal Server Error');
+  console.log(util.inspect(error));
 };
 
 StaticServlet.prototype.sendMissing_ = function(req, res, path) {
@@ -134,7 +134,7 @@ StaticServlet.prototype.sendMissing_ = function(req, res, path) {
     ' was not found on this server.</p>'
   );
   res.end();
-  util.puts('404 Not Found: ' + path);
+  console.log('404 Not Found: ' + path);
 };
 
 StaticServlet.prototype.sendForbidden_ = function(req, res, path) {
@@ -150,7 +150,7 @@ StaticServlet.prototype.sendForbidden_ = function(req, res, path) {
     escapeHtml(path) + ' on this server.</p>'
   );
   res.end();
-  util.puts('403 Forbidden: ' + path);
+  console.log('403 Forbidden: ' + path);
 };
 
 StaticServlet.prototype.sendRedirect_ = function(req, res, redirectUrl) {
@@ -167,7 +167,7 @@ StaticServlet.prototype.sendRedirect_ = function(req, res, redirectUrl) {
     '">here</a>.</p>'
   );
   res.end();
-  util.puts('301 Moved Permanently: ' + redirectUrl);
+  console.log('301 Moved Permanently: ' + redirectUrl);
 };
 
 StaticServlet.prototype.sendFile_ = function(req, res, path) {


### PR DESCRIPTION
Use of "util.puts" is deprecated. The server logs recommend using "console.log" instead. This commit replaces occurrences of "util.puts" with "console.log".